### PR TITLE
Add markdownlint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,19 @@
+name: Markdown lint
+
+on:
+  push:
+    paths:
+      - README.md
+  pull_request:
+    paths:
+      - README.md
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v13
+        with:
+          globs: README.md
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint README

## Testing
- `npx markdownlint README.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68416281ca4483308022e3e77116441e